### PR TITLE
Remove demo canisters and add a link to the encrypted notes sample dapp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # IC Vault
 In order to support Dapps handling sensitive data, we need seamless end-to-end encryption to ensure that the IC does not get to see any confidential or private data.
 
-The `IC Vault` enables the management of key-value pairs linked to a location or application. The `IC Vault` focuses on the transparent access of managed data by all registered devices of a specific user. It is assumed that the devices are added to the user’s Internet Identity. We leverage this fact and thereby demonstrate the power of Internet Identity. By "seamless" we mean that no additional communication between the devices is required, i.e., no scanning of QR codes by one device on another, etc. Each device only communicates directly with the IC. 
+The `IC Vault` enables the management of key-value pairs linked to a location or application. The `IC Vault` focuses on the transparent access of managed data by all registered devices of a specific user. It is assumed that the devices are added to the user’s Internet Identity. We leverage this fact and thereby demonstrate the power of Internet Identity. By "seamless" we mean that no additional communication between the devices is required, i.e., no scanning of QR codes by one device on another, etc. Each device only communicates directly with the IC.
+
+Note that this is a demo project. A more polished encrypted notes sample dapp can be found [here](https://github.com/dfinity/examples/tree/master/motoko/encrypted-notes-dapp). 
 
 ![IC Vault](resources/overview.png)
 

--- a/frontend/canister_ids.json
+++ b/frontend/canister_ids.json
@@ -1,9 +1,9 @@
 {
   "__Candid_UI": {
-      "mercury": "xggrc-cyaaa-aaaaj-aaasq-cai"
+      "mercury": "[INSERT CANISTER PRINCIPAL ID]"
   },
   "www": {
-      "mercury": "xggrc-cyaaa-aaaaj-aaasq-cai",
-      "ic": "xggrc-cyaaa-aaaaj-aaasq-cai"
+      "mercury": "[INSERT CANISTER PRINCIPAL ID]",
+      "ic": "[INSERT CANISTER PRINCIPAL ID]"
   }
 }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -15,9 +15,8 @@ const deviceAliasEl = document.getElementById('deviceAlias');
 const seedResponseEl = document.getElementById('seedResponse');
 const syncResponseEl = document.getElementById('syncResponse');
 
-const keySyncCanister = "khpze-daaaa-aaaai-aal6q-cai";
-const vaultCanister = "uvf7r-liaaa-aaaah-qabnq-cai"; // deployment on IC
-//const vaultCanister = "un4fu-tqaaa-aaaab-qadjq-cai"; // from Motoko playground
+const keySyncCanister = "[INSERT CANISTER PRINCIPAL ID]";
+const vaultCanister = "[INSERT CANISTER PRINCIPAL ID]"; // deployment on IC
 
 const vaultIdlFactory = ({ IDL }) =>
     IDL.Service({

--- a/key_sync/canister_ids.json
+++ b/key_sync/canister_ids.json
@@ -1,9 +1,9 @@
 {
   "__Candid_UI": {
-      "mercury": "khpze-daaaa-aaaai-aal6q-cai"
+      "mercury": "[INSERT CANISTER PRINCIPAL ID]"
   },
   "key_sync": {
-      "mercury": "khpze-daaaa-aaaai-aal6q-cai",
-      "ic": "khpze-daaaa-aaaai-aal6q-cai"
+      "mercury": "[INSERT CANISTER PRINCIPAL ID]",
+      "ic": "[INSERT CANISTER PRINCIPAL ID]"
   }
 }

--- a/kv_store/canister_ids.json
+++ b/kv_store/canister_ids.json
@@ -1,9 +1,9 @@
 {
   "__Candid_UI": {
-      "mercury": "uvf7r-liaaa-aaaah-qabnq-cai"
+      "mercury": "[INSERT CANISTER PRINCIPAL ID]"
   },
   "kv_store": {
-      "mercury": "uvf7r-liaaa-aaaah-qabnq-cai",
-      "ic": "uvf7r-liaaa-aaaah-qabnq-cai"
+      "mercury": "[INSERT CANISTER PRINCIPAL ID]",
+      "ic": "[INSERT CANISTER PRINCIPAL ID]"
   }
 }


### PR DESCRIPTION
This PR removes the principal IDs of the canisters that were used for the demo.
Moreover, it adds a link to the [encrypted notes sample dapp](https://github.com/dfinity/examples/tree/master/motoko/encrypted-notes-dapp).